### PR TITLE
update gogo protobuf

### DIFF
--- a/coding.go
+++ b/coding.go
@@ -13,6 +13,11 @@ import (
 	ipld "github.com/ipfs/go-ipld-format"
 )
 
+// Make sure the user doesn't upgrade this file.
+// We need to check *here* as well as inside the `pb` package *just* in case the
+// user replaces *all* go files in that package.
+const _ = pb.DoNotUpgradeFileEverItWillChangeYourHashes
+
 // for now, we use a PBNode intermediate thing.
 // because native go objects are nice.
 

--- a/node_test.go
+++ b/node_test.go
@@ -9,7 +9,25 @@ import (
 	mdtest "github.com/ipfs/go-merkledag/test"
 
 	ipld "github.com/ipfs/go-ipld-format"
+	cid "github.com/ipfs/go-cid"
 )
+
+func TestStableCID(t *testing.T) {
+	nd := &ProtoNode{}
+	nd.SetData([]byte("foobar"))
+	nd.SetLinks([]*ipld.Link{
+		{Name: "a"},
+		{Name: "b"},
+		{Name: "c"},
+	})
+	expected, err := cid.Decode("QmSN3WED2xPLbYvBbfvew2ZLtui8EbFYYcbfkpKH5jwG9C")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !nd.Cid().Equals(expected) {
+		t.Fatalf("Got CID %s, expected CID %s", nd.Cid(), expected)
+	}
+}
 
 func TestRemoveLink(t *testing.T) {
 	nd := &ProtoNode{}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZ4Qi3GaRbjcx28Sme5eMH7RQjGkt8wHxt2a65oLaeFEV",
+      "hash": "Qme4mBZ8DawL9xJPSzoEnFCHPzEAZ7NTNYoXSqgVBXpXeo",
       "name": "gogo-protobuf",
       "version": "0.0.0"
     },

--- a/pb/merkledag.pb.go
+++ b/pb/merkledag.pb.go
@@ -31,6 +31,15 @@ import strconv "strconv"
 
 import bytes "bytes"
 
+// DoNotUpgradeFileEverItWillChangeYourHashes warns users about not breaking
+// their file hashes.
+const DoNotUpgradeFileEverItWillChangeYourHashes = `
+This file does not produce canonical protobufs. Unfortunately, if we change it,
+we'll change the hashes of the files we produce.
+
+Do *not regenerate this file.
+`
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = math.Inf

--- a/pb/upgrade_check.go
+++ b/pb/upgrade_check.go
@@ -1,0 +1,5 @@
+package merkledag_pb
+
+// Make sure the user doesn't upgrade this package!
+// This will fail to build if the user does.
+const _ = DoNotUpgradeFileEverItWillChangeYourHashes


### PR DESCRIPTION
This will allow us to address https://github.com/libp2p/go-libp2p-kad-dht/issues/177 without forcing us to change the go APIs too much.

We've wanted to do this for a while anyways.