### PR TITLE
fix the protobuf import

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/ipfs/go-merkledag"
 	mdtest "github.com/ipfs/go-merkledag/test"
 
-	ipld "github.com/ipfs/go-ipld-format"
 	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 )
 
 func TestStableCID(t *testing.T) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qme4mBZ8DawL9xJPSzoEnFCHPzEAZ7NTNYoXSqgVBXpXeo",
+      "hash": "QmdxUuburamoF6zF9qjeQC4WYcWGbWuRmdLacMEsW8ioD8",
       "name": "gogo-protobuf",
       "version": "0.0.0"
     },


### PR DESCRIPTION
removes all `// import` directives from the protobuf source