### PR TITLE
perf: avoid allocations when filtering nodes

### DIFF
--- a/node.go
+++ b/node.go
@@ -126,21 +126,25 @@ func (n *ProtoNode) AddRawLink(name string, l *ipld.Link) error {
 // RemoveNodeLink removes a link on this node by the given name.
 func (n *ProtoNode) RemoveNodeLink(name string) error {
 	n.encoded = nil
-	good := make([]*ipld.Link, 0, len(n.links))
-	var found bool
 
-	for _, l := range n.links {
-		if l.Name != name {
-			good = append(good, l)
+	ref := &n.links
+	filterPos := 0
+	found := false
+
+	for i := 0; i < len(*ref); i++ {
+		if v := (*ref)[i]; v.Name != name {
+			(*ref)[filterPos] = v
+			filterPos++
 		} else {
 			found = true
 		}
 	}
-	n.links = good
 
 	if !found {
 		return ipld.ErrNotFound
 	}
+
+	n.links = (*ref)[:filterPos]
 
 	return nil
 }

--- a/node.go
+++ b/node.go
@@ -127,14 +127,12 @@ func (n *ProtoNode) AddRawLink(name string, l *ipld.Link) error {
 func (n *ProtoNode) RemoveNodeLink(name string) error {
 	n.encoded = nil
 
-	ref := &n.links
-	filterPos := 0
+	ref := n.links[:0]
 	found := false
 
-	for i := 0; i < len(*ref); i++ {
-		if v := (*ref)[i]; v.Name != name {
-			(*ref)[filterPos] = v
-			filterPos++
+	for _, v := range n.links {
+		if v.Name != name {
+			ref = append(ref, v)
 		} else {
 			found = true
 		}
@@ -144,7 +142,7 @@ func (n *ProtoNode) RemoveNodeLink(name string) error {
 		return ipld.ErrNotFound
 	}
 
-	n.links = (*ref)[:filterPos]
+	n.links = ref
 
 	return nil
 }


### PR DESCRIPTION
After @whyrusleeping demonstrated us how to find slow code, I went and made this a bit faster.

Test used to profile is in `go-mfs`

![screen shot 2018-08-28 at 21 43 50](https://user-images.githubusercontent.com/790842/44746735-79b9a680-ab0b-11e8-9159-d4c158d00be3.png)

pprof before
![screen shot 2018-08-28 at 21 39 08](https://user-images.githubusercontent.com/790842/44746746-7d4d2d80-ab0b-11e8-8803-15551054c7ec.png)

pprof after
![screen shot 2018-08-28 at 21 37 57](https://user-images.githubusercontent.com/790842/44746748-7f16f100-ab0b-11e8-87d1-dae2a64a5403.png)
