### PR TITLE
gx: update go-libp2p-routing

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.1: QmXv5mwmQ74r4aiHcNeQ4GAmfB3aWJuqaE4WyDfDfvkgLM
+1.1.2: QmVB15p7qNVQQGC5RQcAQAovDFaQpRNqorbRwpvdNjHmVC

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     },
     {
       "author": "why",
-      "hash": "Qma2KhbQarYTkmSJAeaMGRAg8HAXAhEWK8ge4SReG7ZSD3",
+      "hash": "QmWAU1Etv448cx9GLohtr27vnVC87amqE7fN4Hf4hcLDQY",
       "name": "go-blockservice",
-      "version": "1.1.1"
+      "version": "1.1.2"
     }
   ],
   "gxVersion": "0.12.1",
@@ -61,6 +61,6 @@
   "license": "",
   "name": "go-merkledag",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/199
- https://github.com/ipfs/go-ipfs-routing/pull/14
- https://github.com/libp2p/go-libp2p-routing-helpers/pull/8
- https://github.com/libp2p/go-libp2p-pubsub-router/pull/10
- https://github.com/ipfs/go-bitswap/pull/11
- https://github.com/ipfs/go-blockservice/pull/7


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace