### PR TITLE
Wait for all go routines to finish before function returns

### DIFF
--- a/merkledag.go
+++ b/merkledag.go
@@ -376,14 +376,16 @@ func EnumerateChildrenAsyncDepth(ctx context.Context, getLinks GetLinks, c cid.C
 	done := make(chan struct{})
 
 	var setlk sync.Mutex
+	var wg sync.WaitGroup
 
 	errChan := make(chan error)
 	fetchersCtx, cancel := context.WithCancel(ctx)
-
+	defer wg.Wait()
 	defer cancel()
-
 	for i := 0; i < FetchGraphConcurrency; i++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for cdepth := range feed {
 				ci := cdepth.cid
 				depth := cdepth.depth


### PR DESCRIPTION
# Goals

Make sure than when EnumerateChildrenAsync returns, all of it's go routines have completed, even in the case of a context cancel

# Implementation

Add a waitGroup that waits for all of the graph traversal child go routines to terminate before the function terminates

# For Discussion

Reasoning:
See https://github.com/ipfs/go-unixfs/pull/39#discussion_r229400182

In the case of a context cancel, the select loop in the main thread of `EnumerateChildrenAsyncDepth` can receive the cancel before it's processed by the go routines enumerating children. This can cause the `EnumerateChildrenAsyncDepth` to return with these enumeration routines still in progress, and therefore for getLinks() to get called up to one time per channel after the overall routine returns.

The consequences for the caller of the function can be super confusing, since getLinks is provided by the caller, who make not be expecting getLinks to get called after the function returns. A panic can arise if getLinks attempts to write to a channel the caller has closed after EnumerateChildrenAsyncDepth has returned.

child of https://github.com/ipfs/go-ipfs/issues/5600