### PR TITLE
Increase FetchGraphConcurrency to 32

### DIFF
--- a/merkledag.go
+++ b/merkledag.go
@@ -342,7 +342,7 @@ func (p *ProgressTracker) Value() int {
 
 // FetchGraphConcurrency is total number of concurrent fetches that
 // 'fetchNodes' will start at a time
-var FetchGraphConcurrency = 8
+var FetchGraphConcurrency = 32
 
 // EnumerateChildrenAsync is equivalent to EnumerateChildren *except* that it
 // fetches children in parallel.


### PR DESCRIPTION
Given all the bitswap session improvements, I think it's time to give our users some candy. This should allow us to actually take advantage of the increased wantlist sizes.