### PR TITLE
fix some performance regressions when reading protobuf nodes

### DIFF
--- a/coding.go
+++ b/coding.go
@@ -131,7 +131,7 @@ func DecodeProtobufBlock(b blocks.Block) (ipld.Node, error) {
 	}
 
 	decnd.cached = c
-	decnd.SetCidBuilder(c.Prefix())
+	decnd.builder = c.Prefix()
 	return decnd, nil
 }
 

--- a/node.go
+++ b/node.go
@@ -78,7 +78,6 @@ func (n *ProtoNode) SetCidBuilder(builder cid.Builder) {
 		n.builder = v0CidPrefix
 	} else {
 		n.builder = builder.WithCodec(cid.DagProtobuf)
-		n.encoded = nil
 		n.cached = cid.Undef
 	}
 }


### PR DESCRIPTION
This is also a bugfix as we don't want to re-encode nodes unless we change them. If we do and the user chose a non-standard encoding, we could change the CID. This is likely what triggered https://github.com/ipfs/go-ipfs/issues/6011