### PR TITLE
rework the graph walking functions with functional options

### DIFF
--- a/merkledag_test.go
+++ b/merkledag_test.go
@@ -203,8 +203,11 @@ func makeTestDAG(t *testing.T, read io.Reader, ds ipld.DAGService) ipld.Node {
 	// Add a root referencing all created nodes
 	root := NodeWithData(nil)
 	for _, n := range nodes {
-		root.AddNodeLink(n.Cid().String(), n)
-		err := ds.Add(ctx, n)
+		err := root.AddNodeLink(n.Cid().String(), n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ds.Add(ctx, n)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -383,7 +386,7 @@ func TestFetchGraphWithDepthLimit(t *testing.T) {
 
 		}
 
-		err = WalkDepth(context.Background(), offlineDS.GetLinks, root.Cid(), 0, visitF)
+		err = WalkDepth(context.Background(), offlineDS.GetLinks, root.Cid(), visitF, WithRoot())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -736,7 +739,7 @@ func TestEnumerateAsyncFailsNotFound(t *testing.T) {
 	}
 
 	cset := cid.NewSet()
-	err = WalkParallel(ctx, GetLinksDirect(ds), parent.Cid(), cset.Visit)
+	err = Walk(ctx, GetLinksDirect(ds), parent.Cid(), cset.Visit)
 	if err == nil {
 		t.Fatal("this should have failed")
 	}


### PR DESCRIPTION
This PR:
- reduce the walk API to 2 simpler functions
- add consistent and clear control over if the root should be visited
- add control over the concurrency factor

I also want to implement a `IgnoreBadBlock()` options to continue walking even when a bad block is read.

Note: `FetchGraphWithDepthLimit` could be made simpler with a `DepthLimit()` option as well.

@Stebalien 