### PR TITLE
fix: include root in searches by default

### DIFF
--- a/merkledag_test.go
+++ b/merkledag_test.go
@@ -386,7 +386,7 @@ func TestFetchGraphWithDepthLimit(t *testing.T) {
 
 		}
 
-		err = WalkDepth(context.Background(), offlineDS.GetLinks, root.Cid(), visitF, WithRoot())
+		err = WalkDepth(context.Background(), offlineDS.GetLinks, root.Cid(), visitF)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
1. Walk implies walking the entire graph.
2. Avoids a _silent_ breaking change.