### PR TITLE
fix: return ErrLinkNotFound when the _link_ isn't found

### DIFF
--- a/node.go
+++ b/node.go
@@ -138,7 +138,7 @@ func (n *ProtoNode) RemoveNodeLink(name string) error {
 	}
 
 	if !found {
-		return ipld.ErrNotFound
+		return ErrLinkNotFound
 	}
 
 	n.links = ref

--- a/node_test.go
+++ b/node_test.go
@@ -59,7 +59,7 @@ func TestRemoveLink(t *testing.T) {
 
 	// should fail
 	err = nd.RemoveNodeLink("a")
-	if err != ipld.ErrNotFound {
+	if err != ErrLinkNotFound {
 		t.Fatal("should have failed to remove link")
 	}
 


### PR DESCRIPTION
ipld.ErrNotFound should only be used when the underlying node isn't found