### PR TITLE
fix!: keep ProtoNode deserialised state stable until explicit mutation

### DIFF
--- a/coding.go
+++ b/coding.go
@@ -23,6 +23,14 @@ const _ = pb.DoNotUpgradeFileEverItWillChangeYourHashes
 // for now, we use a PBNode intermediate thing.
 // because native go objects are nice.
 
+// pbLinkSlice is a slice of pb.PBLink, similar to LinkSlice but for sorting the
+// PB form
+type pbLinkSlice []*pb.PBLink
+
+func (pbls pbLinkSlice) Len() int           { return len(pbls) }
+func (pbls pbLinkSlice) Swap(a, b int)      { pbls[a], pbls[b] = pbls[b], pbls[a] }
+func (pbls pbLinkSlice) Less(a, b int) bool { return *pbls[a].Name < *pbls[b].Name }
+
 // unmarshal decodes raw data into a *Node instance.
 // The conversion uses an intermediate PBNode.
 func unmarshal(encodedBytes []byte) (*ProtoNode, error) {
@@ -41,6 +49,9 @@ func fromImmutableNode(encoded *immutableProtoNode) *ProtoNode {
 		n.data = n.encoded.PBNode.Data.Must().Bytes()
 	}
 	numLinks := n.encoded.PBNode.Links.Length()
+	// links may not be sorted after deserialization, but we don't change
+	// them until we mutate this node since we're representing the current,
+	// as-serialized state
 	n.links = make([]*format.Link, numLinks)
 	linkAllocs := make([]format.Link, numLinks)
 	for i := int64(0); i < numLinks; i++ {
@@ -60,12 +71,15 @@ func fromImmutableNode(encoded *immutableProtoNode) *ProtoNode {
 		link.Cid = c
 		n.links[i] = link
 	}
+	// we don't set n.linksDirty because the order of the links list from
+	// serialized form needs to be stable, until we start mutating the ProtoNode
 	return n
 }
 func (n *ProtoNode) marshalImmutable() (*immutableProtoNode, error) {
+	links := n.Links()
 	nd, err := qp.BuildMap(dagpb.Type.PBNode, 2, func(ma ipld.MapAssembler) {
-		qp.MapEntry(ma, "Links", qp.List(int64(len(n.links)), func(la ipld.ListAssembler) {
-			for _, link := range n.links {
+		qp.MapEntry(ma, "Links", qp.List(int64(len(links)), func(la ipld.ListAssembler) {
+			for _, link := range links {
 				qp.ListEntry(la, qp.Map(3, func(ma ipld.MapAssembler) {
 					if link.Cid.Defined() {
 						qp.MapEntry(ma, "Hash", qp.Link(cidlink.Link{Cid: link.Cid}))
@@ -113,7 +127,6 @@ func (n *ProtoNode) GetPBNode() *pb.PBNode {
 		pbn.Links = make([]*pb.PBLink, len(n.links))
 	}
 
-	sort.Stable(LinkSlice(n.links)) // keep links sorted
 	for i, l := range n.links {
 		pbn.Links[i] = &pb.PBLink{}
 		pbn.Links[i].Name = &l.Name
@@ -122,6 +135,11 @@ func (n *ProtoNode) GetPBNode() *pb.PBNode {
 			pbn.Links[i].Hash = l.Cid.Bytes()
 		}
 	}
+
+	// Ensure links are sorted prior to encode, regardless of `linksDirty`. They
+	// may not have come sorted if we deserialized a badly encoded form that
+	// didn't have links already sorted.
+	sort.Stable(pbLinkSlice(pbn.Links))
 
 	if len(n.data) > 0 {
 		pbn.Data = n.data
@@ -132,8 +150,13 @@ func (n *ProtoNode) GetPBNode() *pb.PBNode {
 // EncodeProtobuf returns the encoded raw data version of a Node instance.
 // It may use a cached encoded version, unless the force flag is given.
 func (n *ProtoNode) EncodeProtobuf(force bool) ([]byte, error) {
-	sort.Stable(LinkSlice(n.links)) // keep links sorted
-	if n.encoded == nil || force {
+	if n.encoded == nil || n.linksDirty || force {
+		if n.linksDirty {
+			// there was a mutation involving links, make sure we sort before we build
+			// and cache a `Node` form that captures the current state
+			sort.Stable(LinkSlice(n.links))
+			n.linksDirty = false
+		}
 		n.cached = cid.Undef
 		var err error
 		n.encoded, err = n.marshalImmutable()


### PR DESCRIPTION
When decoding a badly serialised block with Links out of order, don't sort
the list until we receive an explicit mutation operation. This ensures stable
DAG traversal ordering based on the links as they appear in the serialised
form and removes surprise-sorting when performing certain operations that
wouldn't be expected to mutate.

The pre-v0.4.0 behaviour was to always sort, but this behaviour wasn't baked
in to the dag-pb spec and wasn't built into go-codec-dagpb which now forms the
backend of ProtoNode, although remnants of sorting remain in some operations.
Almost all CAR-from-DAG creation code in Go uses go-codec-dagpb and
go-ipld-prime's traversal engine. However this can result in a different order
when encountering badly encoded blocks (unsorted Links) where certain
intermediate operations are performed on the ProtoNode prior to obtaining the
`Links()` list (`Links()` itself doesn't sort, but e.g. `RawData()` does).

The included "TestLinkSorting/decode" test is the only case that passes without
this patch.

Ref: https://github.com/ipld/ipld/pull/233
Ref: https://github.com/filecoin-project/boost/issues/673
Ref: https://github.com/filecoin-project/boost/pull/675

---

Further notes:

* Yes, in an ideal world we could rewind a couple of years and bake sort-on-decode into the dag-pb spec and go-codec-dagpb, but that's not the case and our most important stable-DAG-traversals are happening in CARs now which are almost exclusively using the new stack.
* Our JavaScript codecs don't sort-on-decode.
* All old and new Go and JavaScript codecs in the ipfs and ipld orgs properly sort on encode. However, there now exist multiple implementations of dag-pb that do not follow this part of the spec, and we're now encountering them in places where stable-DAG-traversals really matter.
* This is really a continuation of the ipld-in-ipfs work that lead to v0.4.0, we're just fine tuning a weird corner case.