### PR TITLE
feat: check links on setting and sanitise on encoding

### DIFF
--- a/node.go
+++ b/node.go
@@ -406,19 +406,12 @@ func (n *ProtoNode) MarshalJSON() ([]byte, error) {
 // Cid returns the node's Cid, calculated according to its prefix
 // and raw data contents.
 func (n *ProtoNode) Cid() cid.Cid {
-	if n.encoded != nil && n.cached.Defined() {
-		return n.cached
-	}
-
-	c, err := n.CidBuilder().Sum(n.RawData())
-	if err != nil {
-		// programmer error
-		err = fmt.Errorf("invalid CID of length %d: %x: %v", len(n.RawData()), n.RawData(), err)
+	// re-encode if necessary and we'll get a new cached CID
+	if _, err := n.EncodeProtobuf(false); err != nil {
 		panic(err)
 	}
 
-	n.cached = c
-	return c
+	return n.cached
 }
 
 // String prints the node's Cid.
@@ -428,14 +421,7 @@ func (n *ProtoNode) String() string {
 
 // Multihash hashes the encoded data of this node.
 func (n *ProtoNode) Multihash() mh.Multihash {
-	// NOTE: EncodeProtobuf generates the hash and puts it in n.cached.
-	_, err := n.EncodeProtobuf(false)
-	if err != nil {
-		// Note: no possibility exists for an error to be returned through here
-		panic(err)
-	}
-
-	return n.cached.Hash()
+	return n.Cid().Hash()
 }
 
 // Links returns a copy of the node's links.

--- a/node.go
+++ b/node.go
@@ -271,6 +271,11 @@ func (n *ProtoNode) Copy() format.Node {
 	return nnode
 }
 
+// RawData returns the encoded byte form of this node.
+//
+// Note that this method can panic if a new encode is required and there is an
+// error performing the encode. To avoid a panic, use node.EncodeProtobuf(false)
+// instead (or prior to calling RawData) and check for its returned error value.
 func (n *ProtoNode) RawData() []byte {
 	out, err := n.EncodeProtobuf(false)
 	if err != nil {
@@ -405,21 +410,35 @@ func (n *ProtoNode) MarshalJSON() ([]byte, error) {
 
 // Cid returns the node's Cid, calculated according to its prefix
 // and raw data contents.
+//
+// Note that this method can panic if a new encode is required and there is an
+// error performing the encode. To avoid a panic, call
+// node.EncodeProtobuf(false) prior to calling Cid and check for its returned
+// error value.
 func (n *ProtoNode) Cid() cid.Cid {
 	// re-encode if necessary and we'll get a new cached CID
 	if _, err := n.EncodeProtobuf(false); err != nil {
 		panic(err)
 	}
-
 	return n.cached
 }
 
 // String prints the node's Cid.
+//
+// Note that this method can panic if a new encode is required and there is an
+// error performing the encode. To avoid a panic, call
+// node.EncodeProtobuf(false) prior to calling String and check for its returned
+// error value.
 func (n *ProtoNode) String() string {
 	return n.Cid().String()
 }
 
 // Multihash hashes the encoded data of this node.
+//
+// Note that this method can panic if a new encode is required and there is an
+// error performing the encode. To avoid a panic, call
+// node.EncodeProtobuf(false) prior to calling Multihash and check for its
+// returned error value.
 func (n *ProtoNode) Multihash() mh.Multihash {
 	return n.Cid().Hash()
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.7.0"
+  "version": "v0.8.0"
 }


### PR DESCRIPTION
Attempt to keep ProtoNode always in a state that can be encoded without errors to avoid cases where the panicing methods may be forced to panic on error.

go-codec-dagpb will error when encoding either of the following cases:

* The Hash field in links should always be set, cannot be cid.Undef
* The Tsize field needs to fit into an int64, otherwise it'll overflow to negative which is not allowed

Error on cases where a user may attempt to set links that will eventually error on encode. Then when we do encode, silently handle these cases if they manage to slip through (e.g. if they come in from a decoded block with a bad form).