### PR TITLE
Update README.md and added CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@rvagg @willscott @masih @hannahhoward
+@rvagg

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@rvagg @willscott @masih @hannahhoward

--- a/README.md
+++ b/README.md
@@ -3,15 +3,14 @@ go-merkledag
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 [![Coverage Status](https://codecov.io/gh/ipfs/go-merkledag/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-merkledag/branch/master)
-[![Travis CI](https://travis-ci.org/ipfs/go-merkledag.svg?branch=master)](https://travis-ci.org/ipfs/go-merkledag)
 
 > go-merkledag implements the 'DAGService' interface and adds two ipld node types, Protobuf and Raw 
 
-## Lead Maintainer
+## Status
 
-[Steven Allen](https://github.com/Stebalien)
+❗ This repo is not actively maintained and it should ideally be deprecated.  
+The version that is still used within Kubo lives in https://github.com/ipfs/boxp/tree/main/ipld/merkledag 
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ go-merkledag
 ## Status
 
 ❗ This repo is not actively maintained and it should ideally be deprecated.  
-The version that is still used within Kubo lives in https://github.com/ipfs/boxp/tree/main/ipld/merkledag 
+The version that is still used within Kubo lives in https://github.com/ipfs/boxo/tree/main/ipld/merkledag 
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -9,28 +9,11 @@ go-merkledag
 
 ## Status
 
-❗ This repo is not actively maintained and it should ideally be deprecated.  
-The version that is still used within Kubo lives in https://github.com/ipfs/boxo/tree/main/ipld/merkledag 
+❗ This library is maintained, but not actively developed. It will continue to receive fixes and security updates for users that depend on it. However, it may be deprecated in the future and it is recommended that you use alternatives to the functionality in go-merkledag, including:
 
-## Table of Contents
-
-- [TODO](#todo)
-- [Contribute](#contribute)
-- [License](#license)
-
-## TODO
-
-- Pull out dag-pb stuff into go-ipld-pb
-- Pull 'raw nodes' out into go-ipld-raw (maybe main one instead)
-- Move most other logic to go-ipld
-- Make dagservice constructor take a 'blockstore' to avoid the blockservice offline nonsense
-- deprecate this package
-
-## Contribute
-
-PRs are welcome!
-
-Small note: If editing the Readme, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+* A fork of this library for use by Kubo is being maintained here: [github.com/ipfs/boxo/ipld/merkledag](https://pkg.go.dev/github.com/ipfs/boxo/ipld/merkledag)
+* Working directly with DAG-PB (ProtoNode) should directly use [github.com/ipld/go-codec-dagpb](https://pkg.go.dev/github.com/ipld/go-codec-dagpb) in conjunction with [github.com/ipld/go-ipld-prime](https://pkg.go.dev/github.com/ipld/go-ipld-prime)
+* Traversals / DAG walking should use [github.com/ipld/go-ipld-prime/traversal](https://pkg.go.dev/github.com/ipld/go-ipld-prime/traversal)
 
 ## License
 


### PR DESCRIPTION
Making clear the repo status per https://github.com/ipfs/boxo/issues/218

Note that no "deprecated types" are being added.  There is only a general notice that this repo is on a deprecation path and a pointer to the code copy that Kubo uses.  Any code that @ipfs/kubo-maintainers own will switch to the Boxo version.  A CODEOWNERS was added to clarify who will look at any PRs or do mandatory fixes here (likely in sync with @ipfs/kubo-maintainers since both sides are generally only doing critical changes here.)